### PR TITLE
xiaomi_touch.c: declare a prototype on a function withoud a

### DIFF
--- a/drivers/input/touchscreen/xiaomi/xiaomi_touch.c
+++ b/drivers/input/touchscreen/xiaomi/xiaomi_touch.c
@@ -148,12 +148,12 @@ struct xiaomi_touch *xiaomi_touch_dev_get(int minor)
 		return NULL;
 }
 
-struct class *get_xiaomi_touch_class()
+struct class *get_xiaomi_touch_class(void)
 {
 	return xiaomi_touch_dev.class;
 }
 
-struct device *get_xiaomi_touch_dev()
+struct device *get_xiaomi_touch_dev(void)
 {
 	return xiaomi_touch_dev.dev;
 }


### PR DESCRIPTION
 prototype

is deprecated now

[clang16 fixes]
Signed-off-by: klozz <carlosj@klozz.dev>